### PR TITLE
Recursive project finder

### DIFF
--- a/autoload/fzfproject.vim
+++ b/autoload/fzfproject.vim
@@ -44,7 +44,7 @@ endfunction
 function! s:getAllDirsFromWorkspaces(workspaces)
   let l:dirs = globpath(join(a:workspaces, ','), '*/', 1)
   let l:output = []
-  let l:nonGitDirs
+  let l:nonGitDirs = []
   for dir in split(l:dirs, "\n")
     if FugitiveIsGitDir(dir . '/.git')
       call add(l:output, fnamemodify(dir, ':h'))

--- a/autoload/fzfproject.vim
+++ b/autoload/fzfproject.vim
@@ -39,9 +39,11 @@ function! s:switchToProjectDir(projectLine)
   endtry
 endfunction
 
-" TODO: for each dir, if it is a git dir, add it to the list, otherwise
-" recurse
 function! s:getAllDirsFromWorkspaces(workspaces)
+  " base case
+  if len(a:workspaces) == 0
+    return []
+  endif
   let l:dirs = globpath(join(a:workspaces, ','), '*/', 1)
   let l:output = []
   let l:nonGitDirs = []

--- a/autoload/fzfproject.vim
+++ b/autoload/fzfproject.vim
@@ -39,13 +39,20 @@ function! s:switchToProjectDir(projectLine)
   endtry
 endfunction
 
+" TODO: for each dir, if it is a git dir, add it to the list, otherwise
+" recurse
 function! s:getAllDirsFromWorkspaces(workspaces)
   let l:dirs = globpath(join(a:workspaces, ','), '*/', 1)
   let l:output = []
+  let l:nonGitDirs
   for dir in split(l:dirs, "\n")
-    call add(l:output, fnamemodify(dir, ':h'))
+    if FugitiveIsGitDir(dir . '/.git')
+      call add(l:output, fnamemodify(dir, ':h'))
+    else
+      call add(l:nonGitDirs, fnamemodify(dir, ':h'))
+    endif
   endfor
-  return l:output
+  return l:output + s:getAllDirsFromWorkspaces(l:nonGitDirs)
 endfunction
 
 function! s:formatProjectList(dirs)


### PR DESCRIPTION
Changes the getAllDirsFromWorkspaces function to be recursive, so you can add a parent folder to your list of workspaces, and it will find all git repositories inside that parent folder.